### PR TITLE
Handle default siteverify_endpoint better

### DIFF
--- a/friendly_captcha_client/client.py
+++ b/friendly_captcha_client/client.py
@@ -102,7 +102,7 @@ class FriendlyCaptchaClient:
         self.logger = logging.getLogger(__name__)
         self.verbose = verbose
 
-        if siteverify_endpoint == None or siteverify_endpoint == "global":
+        if siteverify_endpoint is None or siteverify_endpoint == "global":
             siteverify_endpoint = GLOBAL_SITEVERIFY_ENDPOINT
         elif siteverify_endpoint == "eu":
             siteverify_endpoint = EU_SITEVERIFY_ENDPOINT


### PR DESCRIPTION
This PR changes the handling of the default value of `siteverify_endpoint` to also allow for passing in `None` (as we do in the [example](https://github.com/FriendlyCaptcha/friendly-captcha-python/blob/main/example/main.py#L27) if it's not set).